### PR TITLE
feat: add firebase login via local API

### DIFF
--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { signInWithEmailAndPassword } from "firebase/auth";
+import { auth } from "@/lib/firebase";
+
+export async function POST(req: Request) {
+  try {
+    const { email, password } = await req.json();
+    const userCredential = await signInWithEmailAndPassword(auth, email, password);
+    const token = await userCredential.user.getIdToken();
+    return NextResponse.json({ uid: userCredential.user.uid, token });
+  } catch (error) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ error: "Unknown error" }, { status: 400 });
+  }
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import * as React from "react";
+
+export default function LoginPage() {
+  const [email, setEmail] = React.useState("");
+  const [password, setPassword] = React.useState("");
+  const [error, setError] = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Erro ao entrar");
+      }
+      console.log("Logged in:", data);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Erro inesperado");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="w-full h-dvh flex justify-center items-center">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          className="w-full p-2 border rounded"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Senha"
+          className="w-full p-2 border rounded"
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full p-2 bg-blue-500 text-white rounded"
+        >
+          {loading ? "Entrando..." : "Entrar"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/env.example
+++ b/env.example
@@ -1,0 +1,3 @@
+FIREBASE_API_KEY=your_api_key
+FIREBASE_AUTH_DOMAIN=your_auth_domain
+FIREBASE_PROJECT_ID=your_project_id

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,0 +1,18 @@
+import { initializeApp, getApps, FirebaseApp } from "firebase/app";
+import { getAuth } from "firebase/auth";
+
+const firebaseConfig = {
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+};
+
+let app: FirebaseApp;
+if (getApps().length) {
+  app = getApps()[0];
+} else {
+  app = initializeApp(firebaseConfig);
+}
+
+export const auth = getAuth(app);
+export default app;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.542.0",
+    "firebase": "^11.0.1",
     "next": "15.5.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
## Summary
- add login page that posts credentials to local API
- create Next.js API route to authenticate with Firebase
- configure Firebase SDK and document required env vars

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b1b3043560832ab07fbb3bc075a721