### PR TITLE
Secure login token storage and middleware validation

### DIFF
--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -37,7 +37,6 @@ export default function LoginPage() {
         onBeforeInstall as EventListener
       );
   }, []);
-  console.log("api-key ", process.env.NEXT_PUBLIC_FIREBASE_API_KEY);
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
@@ -52,7 +51,6 @@ export default function LoginPage() {
       if (!res.ok) {
         throw new Error(data.error || "Erro ao entrar");
       }
-      document.cookie = `token=${data.token}; path=/`;
       router.push("/");
     } catch (err) {
       if (err instanceof Error) {
@@ -106,7 +104,7 @@ export default function LoginPage() {
             className="w-full p-2 border rounded-md"
             required
           />
-          {/* {error && <p className="text-red-500 text-sm">{error}</p>} */}
+          {error && <p className="text-red-500 text-sm">{error}</p>}
           <button
             type="submit"
             disabled={loading}

--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -7,7 +7,19 @@ export async function POST(req: Request) {
     const { email, password } = await req.json();
     const userCredential = await signInWithEmailAndPassword(auth, email, password);
     const token = await userCredential.user.getIdToken();
-    return NextResponse.json({ uid: userCredential.user.uid, token });
+
+    const response = NextResponse.json({ uid: userCredential.user.uid });
+
+    response.cookies.set({
+      name: "token",
+      value: token,
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+    });
+
+    return response;
   } catch (error) {
     if (error instanceof Error) {
       return NextResponse.json({ error: error.message }, { status: 400 });

--- a/lib/verify-firebase-token.ts
+++ b/lib/verify-firebase-token.ts
@@ -1,0 +1,58 @@
+const API_URL = "https://identitytoolkit.googleapis.com/v1/accounts:lookup";
+
+interface FirebaseLookupResponse {
+  users?: Array<{
+    localId?: string;
+    email?: string;
+    displayName?: string;
+  }>;
+}
+
+export interface VerifiedFirebaseUser {
+  uid: string;
+  email?: string | null;
+  displayName?: string | null;
+}
+
+export async function verifyFirebaseToken(
+  idToken: string
+): Promise<VerifiedFirebaseUser | null> {
+  const apiKey = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
+
+  if (!apiKey) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(`${API_URL}?key=${apiKey}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ idToken }),
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as FirebaseLookupResponse;
+
+    if (!data.users || data.users.length === 0) {
+      return null;
+    }
+
+    const user = data.users[0];
+
+    if (!user?.localId) {
+      return null;
+    }
+
+    return {
+      uid: user.localId,
+      email: user.email ?? null,
+      displayName: user.displayName ?? null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,17 +1,30 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-export function middleware(req: NextRequest) {
+import { verifyFirebaseToken } from "./lib/verify-firebase-token";
+export async function middleware(req: NextRequest) {
   const token = req.cookies.get("token")?.value;
   const { pathname } = req.nextUrl;
 
   const isLoginRoute = pathname === "/login";
 
-  if (!token && !isLoginRoute) {
-    return NextResponse.redirect(new URL("/login", req.url));
+  if (!token) {
+    if (!isLoginRoute) {
+      return NextResponse.redirect(new URL("/login", req.url));
+    }
+
+    return NextResponse.next();
   }
 
-  if (token && isLoginRoute) {
+  const user = await verifyFirebaseToken(token);
+
+  if (!user) {
+    const response = NextResponse.redirect(new URL("/login", req.url));
+    response.cookies.delete("token");
+    return response;
+  }
+
+  if (isLoginRoute) {
     return NextResponse.redirect(new URL("/", req.url));
   }
 


### PR DESCRIPTION
## Summary
- store the Firebase ID token in an HttpOnly cookie from the login API and limit the response payload
- update the login page to rely on the API response instead of document.cookie and surface errors to users
- add a Firebase token verification helper and use it in middleware to validate tokens before allowing navigation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc0f1da030832aab59f412f32b85b5