### PR TITLE
Remove sensitive console log from login page

### DIFF
--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -37,7 +37,6 @@ export default function LoginPage() {
         onBeforeInstall as EventListener
       );
   }, []);
-  console.log("api-key ", process.env.NEXT_PUBLIC_FIREBASE_API_KEY);
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");


### PR DESCRIPTION
## Summary
- remove the Firebase API key console log from the login page
- verify no other console logs remain in the authentication flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0f1e0fac832ab2800e8f183392a2